### PR TITLE
Fix missing acquisition link in linkraw

### DIFF
--- a/nwb_datajoint/data_import/insert_sessions.py
+++ b/nwb_datajoint/data_import/insert_sessions.py
@@ -55,6 +55,7 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
 
             # add link to raw ephys ElectricalSeries from raw data file
             nwbf_export.add_acquisition(raw_ephys)
+            nwbf_export.set_modified()  # workaround until the above sets modified=True on the file
 
             export_io.write(nwbf_export)
 


### PR DESCRIPTION
Fix #21.

My bad - I forgot about a change I made in HDMF to make the last set of changes work. Since it could be some time before a new version of HDMF is released, I use a simple workaround here to make sure that the new linkraw file contains a link to the raw data in the original file.