### PR TITLE
Fix sorting code to use moved n_noise_waveforms param

### DIFF
--- a/notebooks/nwbdj_spikeinterface_test.ipynb
+++ b/notebooks/nwbdj_spikeinterface_test.ipynb
@@ -29,19 +29,35 @@
     "import pynwb\n",
     "import os\n",
     "\n",
-    "data_dir = Path('/Users/loren/data/nwb_builder_test_data') # CHANGE ME TO THE BASE DIRECTORY FOR DATA STORAGE ON YOUR SYSTEM\n",
+    "# CHANGE ME TO THE BASE DIRECTORY FOR DATA STORAGE ON YOUR SYSTEM\n",
+    "# data_dir = Path('/Users/loren/data/nwb_builder_test_data') \n",
+    "data_dir = Path('/mnt/c/Users/Ryan/Documents/NWB_Data/Frank Lab Data/')\n",
+    "\n",
+    "raw_dir = data_dir / 'raw'\n",
+    "analysis_dir = data_dir / 'analysis'\n",
     "\n",
     "os.environ['NWB_DATAJOINT_BASE_DIR'] = str(data_dir)\n",
     "os.environ['KACHERY_STORAGE_DIR'] = str(data_dir / 'kachery-storage')\n",
     "os.environ['SPIKE_SORTING_STORAGE_DIR'] = str(data_dir / 'spikesorting')\n",
+    "os.environ['DJ_SUPPORT_FILEPATH_MANAGEMENT'] = 'TRUE'\n",
     "\n",
     "# DataJoint and DataJoint schema\n",
-    "\n",
     "import datajoint as dj\n",
-    "\n",
     "dj.config['database.host'] = 'localhost'\n",
     "dj.config['database.user'] = 'root'\n",
     "dj.config['database.password'] = 'tutorial'\n",
+    "dj.config['stores'] = {\n",
+    "  'raw': {\n",
+    "    'protocol': 'file',\n",
+    "    'location': str(raw_dir),\n",
+    "    'stage' : str(raw_dir)\n",
+    "  },\n",
+    "  'analysis': {\n",
+    "    'protocol': 'file',\n",
+    "    'location': str(analysis_dir),\n",
+    "    'stage': str(analysis_dir)\n",
+    "  }\n",
+    "}\n",
     "\n",
     "import nwb_datajoint as nd\n",
     "from ndx_franklab_novela import Probe\n",
@@ -75,7 +91,8 @@
    "outputs": [],
    "source": [
     "#nwb_file_name = (nd.common.Session() & {'session_id': 'beans_01'}).fetch1('nwb_file_name')\n",
-    "nwb_file_name = 'beans20190718_.nwb'"
+    "# nwb_file_name = 'beans20190718_.nwb'\n",
+    "nwb_file_name = 'beans20190718-trim_.nwb'"
    ]
   },
   {
@@ -171,7 +188,10 @@
     "param['clip_size'] = 30\n",
     "param['noise_overlap_threshold'] = 0\n",
     "\n",
-    "nd.common.SpikeSorterParameters().insert1({'sorter_name': 'mountainsort4', 'parameter_set_name' : 'franklab_mountainsort_20KHz', 'parameter_dict' : param}, skip_duplicates='True')"
+    "nd.common.SpikeSorterParameters().insert1({'sorter_name': 'mountainsort4', \n",
+    "                                           'parameter_set_name': 'franklab_mountainsort_20KHz', \n",
+    "                                           'parameter_dict' : param}, \n",
+    "                                          skip_duplicates='True')"
    ]
   },
   {
@@ -187,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p = (nd.common.SpikeSorterParameters() & {'sorter_name': 'mountainsort4', 'parameter_set_name' : 'franklab_mountainsort_20KHz'}).fetch1()\n",
+    "p = (nd.common.SpikeSorterParameters() & {'sorter_name': 'mountainsort4', 'parameter_set_name': 'franklab_mountainsort_20KHz'}).fetch1()\n",
     "p"
    ]
   },
@@ -214,25 +234,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nd.common.IntervalList()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# create a 10 second test intervals for debugging\n",
-    "s1 = (nd.common.IntervalList() & {'interval_list_name' : '01_s1'}).fetch1('valid_times')\n",
+    "s1 = (nd.common.IntervalList() & {'interval_list_name': '01_s1'}).fetch1('valid_times')\n",
     "print(s1)\n",
     "\n",
-    "\n",
     "a = np.asarray([s1[0][0], s1[0][0]+240])\n",
-    "#t = np.vstack((t, np.asarray([[a+120,b+120]])))\n",
-    "nd.common.SortInterval().insert1({'nwb_file_name' : nwb_file_name, 'sort_interval_name' : 'test', 'sort_interval' : a}, replace='True')\n",
+    "print(a)\n",
     "\n",
-    "print(a)"
+    "nd.common.SortInterval().insert1({'nwb_file_name': nwb_file_name, 'sort_interval_name': 'test', 'sort_interval': a}, replace='True')"
    ]
   },
   {
@@ -242,7 +251,6 @@
    "outputs": [],
    "source": [
     "# create the sorting waveform parameters table\n",
-    "n_noise_waveforms = 1000 # the number of random noise waveforms to save\n",
     "waveform_param_dict = st.postprocessing.get_waveforms_params()\n",
     "waveform_param_dict['grouping_property'] = 'group'\n",
     "# set the window to half of the clip size before and half after\n",
@@ -251,8 +259,10 @@
     "waveform_param_dict['dtype'] = 'i2'\n",
     "waveform_param_dict['verbose'] = False\n",
     "waveform_param_dict['max_spikes_per_unit'] = 1000\n",
-    "nd.common.SpikeSortingWaveformParameters.insert1({'waveform_parameters_name' : 'franklab default', 'n_noise_waveforms' : n_noise_waveforms, \n",
-    "                                                   'waveform_parameter_dict' : waveform_param_dict}, replace='True')"
+    "nd.common.SpikeSortingWaveformParameters.insert1({'waveform_parameters_name': 'franklab default', \n",
+    "                                                  'waveform_parameter_dict': waveform_param_dict}, \n",
+    "                                                 replace='True')\n",
+    "nd.common.SpikeSortingWaveformParameters()"
    ]
   },
   {
@@ -316,9 +326,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nd.common.SpikeSortingMetrics().insert1({'cluster_metrics_list_name' : 'll_fl_probe_metrics', \n",
-    "                             'n_cluster_waveforms' : n_cluster_waveforms,\n",
-    "                             'metrics_dict' : metric_dict}, skip_duplicates='True')"
+    "nd.common.SpikeSortingMetrics().insert1({'cluster_metrics_list_name': 'll_fl_probe_metrics', \n",
+    "                                         'n_cluster_waveforms' : n_cluster_waveforms,\n",
+    "                                         'metrics_dict' : metric_dict}, \n",
+    "                                        skip_duplicates='True')\n",
+    "nd.common.SpikeSortingMetrics()"
    ]
   },
   {
@@ -337,7 +349,8 @@
     "key['interval_list_name'] = '01_s1'\n",
     "key['sort_interval_name'] = 'test'\n",
     "key['cluster_metrics_list_name'] = 'll_fl_probe_metrics'\n",
-    "nd.common.SpikeSortingParameters().insert1(key, skip_duplicates='True')"
+    "nd.common.SpikeSortingParameters().insert1(key, skip_duplicates='True')\n",
+    "nd.common.SpikeSortingParameters()"
    ]
   },
   {

--- a/nwb_datajoint/common/common_spikesorting.py
+++ b/nwb_datajoint/common/common_spikesorting.py
@@ -466,7 +466,8 @@ class SpikeSorting(dj.Computed):
             # start by getting the first and last frame for this epoch
             #frames = recording_extractor_cached.get_epoch_info(str(sort_interval_index))
             rng = np.random.default_rng()
-            noise_frames = np.sort(np.random.randint(0, recording_extractor_cached.get_num_frames(), sorting_waveform_param['n_noise_waveforms']))
+            n_noise_waveforms = (SpikeSortingMetrics() & metrics_key).fetch1('n_noise_waveforms')
+            noise_frames = np.sort(np.random.randint(0, recording_extractor_cached.get_num_frames(), n_noise_waveforms))
                 
             noise_sorting=se.NumpySortingExtractor()
             noise_sorting.set_times_labels(times=noise_frames,labels=np.zeros(noise_frames.shape))


### PR DESCRIPTION
`nd.common.SpikeSortingWaveformParameters` no longer contains the `'n_noise_waveforms'` parameter. This parameter was moved to `nd.common.SpikeSortingMetrics` in https://github.com/LorenFrankLab/nwb_datajoint/commit/ec9d14df13339b449c1614acc84e1008cee3cc8b. This PR updates `nwbdj_spikeinterface_test.ipynb` and `SpikeSorting.make(...)` to account for that change.

Changes:
1. update notebook to 
   a. work with new filestore method in datajoint
   b. use filename 'beans20190718-trim_.nwb'
   c. update inputs to `nd.common.SpikeSortingWaveformParameters.insert1(...)
   d. minor formatting
2. update `SpikeSorting.make` to get `n_noise_waveforms` from `SpikeSortingMetrics`