### PR TITLE
ad hoc fix for spikeextractors keyword argument

### DIFF
--- a/nwb_datajoint/common/common_spikesorting.py
+++ b/nwb_datajoint/common/common_spikesorting.py
@@ -440,7 +440,8 @@ class SpikeSorting(dj.Computed):
         # Write recording extractor to NWB file
         se.NwbRecordingExtractor.write_recording(recording,
                                                  save_path = extractor_nwb_path,
-                                                 overwrite = True)
+                                                 # overwrite = True)
+                                                 )
 
         # Run spike sorting
         print(f'\nRunning spike sorting on {key}...')


### PR DESCRIPTION
Fix #29, for now, by simply commenting out the `overwrite` option.