### PR TITLE
fix prerequisites and overwrite behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ The Frank lab Datajoint database is designed to facilitate data storage, analysi
    jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build
    jupyter labextension install jupyterlab/labbox_ephys_widgets_jp
    ```
+5. Install latest versions of spikeextractors and spiketoolkit packages.
+   * For now we will install these packages locally, because some of the pre-release features are useful for us.
+   ```bash
+   # Install spikeextractors
+   cd ..
+   git clone https://github.com/SpikeInterface/spikeextractors.git
+   cd spikeextractors
+   pip install -e .
+   # Install spiketoolkit
+   cd ..
+   git clone https://github.com/SpikeInterface/spiketoolkit.git
+   cd spikeextractors
+   pip install -e .
+   ```
 
 ### Setting up database access
 1. Ask Loren or Eric to set up an account for you on the Frank lab database (`lmf-db.cin.ucsf.edu`). Note that you have to be connected to UCSF LAN to access this server.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The Frank lab Datajoint database is designed to facilitate data storage, analysi
    # Install spiketoolkit
    cd ..
    git clone https://github.com/SpikeInterface/spiketoolkit.git
-   cd spikeextractors
+   cd spiketoolkit
    pip install -e .
    ```
 

--- a/franklab_kachery-p2p_config.yaml
+++ b/franklab_kachery-p2p_config.yaml
@@ -1,0 +1,13 @@
+---
+bootstrapAddresses:
+  -
+    hostName: 45.33.92.31
+    port: 46103
+  -
+    hostName: 45.33.92.33
+    port: 46103
+channels:
+  -
+    channelName: franklab
+  -
+    channelName: flatiron3

--- a/nwb_datajoint/common/common_spikesorting.py
+++ b/nwb_datajoint/common/common_spikesorting.py
@@ -35,6 +35,9 @@ from requests.exceptions import ConnectionError
 
 schema = dj.schema('common_spikesorting')
 
+_OVERWRITE_SORTING_RESULTS = True
+
+
 @schema
 class SortGroup(dj.Manual):
     definition = """
@@ -434,13 +437,14 @@ class SpikeSorting(dj.Computed):
                            + '_' + str(key['parameter_set_name'])
         analysis_path = str(Path(os.environ['SPIKE_SORTING_STORAGE_DIR'])
                             / key['analysis_file_name'])
-        os.mkdir(analysis_path)
+        os.makedirs(analysis_path, exist_ok=_OVERWRITE_SORTING_RESULTS)
+        # os.mkdir(analysis_path)
         extractor_nwb_path = str(Path(analysis_path) / unique_file_name) + '.nwb'
 
         # Write recording extractor to NWB file
         se.NwbRecordingExtractor.write_recording(recording,
                                                  save_path = extractor_nwb_path,
-                                                 overwrite = True)
+                                                 overwrite = _OVERWRITE_SORTING_RESULTS)
 
         # Run spike sorting
         print(f'\nRunning spike sorting on {key}...')

--- a/run_kachery_p2p_daemon.sh
+++ b/run_kachery_p2p_daemon.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+logdir="_log"
+mkdir -p $logdir
+logfile="${logdir}/kachery_p2p_daemon.log"
+
+nohup kachery-p2p-start-daemon --label franklab --static-config franklab_kachery-p2p_config.yaml > "$logfile" 2>&1 &
+


### PR DESCRIPTION
Please feel free to take or drop any of these changes @khl02007 

- Added config file and script to run kachery_p2p daemon in the background. The config file is downloaded from Kyu's git gist (the url). I had to change the option from `--config` to `--static-config`. The bash script (with nohup and stout directing) is useful for me, but not sure if/where you want to keep it in this repository.
- Updated README with instructions to install spikeextractors and spiketoolkit packages locally. This should fix #29 .
- Fixed makedirs() behavior to prevent error when overwriting analysis path.