### PR TITLE
Update test framework to more working state

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-cov

--- a/src/nwb_datajoint/tests/conftest.py
+++ b/src/nwb_datajoint/tests/conftest.py
@@ -1,13 +1,11 @@
 import pytest
 import sys
 import os
+from .fixtures._datajoint_server import datajoint_server
+
 
 thisdir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(thisdir)
-
-pytest_plugins = [
-    "fixtures._datajoint_server"
-]
 
 def pytest_addoption(parser):
     parser.addoption('--current', action='store_true', dest="current",
@@ -19,10 +17,10 @@ def pytest_configure(config):
     )
 
     markexpr_list = []
-    
+
     if config.option.current:
         markexpr_list.append('current')
-    
+
     if len(markexpr_list) > 0:
         markexpr = ' and '.join(markexpr_list)
         setattr(config.option, 'markexpr', markexpr)


### PR DESCRIPTION
Prior to this PR, tests were not runnable for several reasons:
1. Error `Defining 'pytest_plugins' in a non-top-level conftest is no longer supported` (@khl02007 FYI)
2. Imports have changed
3. Data directories have changed
4. File path handling (str vs path) has changed
5. Package now assumes there is an `ElectricalSeries` named "e-series" in the file
6. possibly other reasons to be discovered.

So far, I have addressed issues 1-3 in this PR. Tests currently fail because of issues 4 and 5 (at least). I am sorting out issue 5 in a separate PR not yet pushed. 

Also, some tests may no longer be needed and should be removed if not needed. And some files have the word "test" in them (e.g. in `notebooks/`) which make them automatically run by `pytest`. It seems like these may have been one-off tests that do not need to be stored in the repo, but if desired to be stored, they should ideally be renamed to remove the "test" part.

I will work on the remaining issues above so that the current tests will pass. This is not done yet, but @khl02007 feel free to merge this so that you can write tests more easily. If you do merge it, I will continue in a separate PR.