### PR TITLE
Fix get_electrode_indices for given ElectricalSeries

### DIFF
--- a/src/nwb_datajoint/common/nwb_helper_fn.py
+++ b/src/nwb_datajoint/common/nwb_helper_fn.py
@@ -202,13 +202,13 @@ def get_electrode_indices(nwb_object, electrode_ids):
         Array of indices of the specified electrode IDs.
     """
     if isinstance(nwb_object, pynwb.ecephys.ElectricalSeries):
-        # electrode_table_region = list(electrical_series.electrodes.to_dataframe().index)  # TODO verify
-        # dynamictableregion of row indices
-        electrode_table_indices = nwb_object.electrodes.data[:]
+        electrodes_table = nwb_object.electrodes.table
     elif isinstance(nwb_object, pynwb.NWBFile):
-        electrode_table_indices = nwb_object.electrodes.id[:]
+        electrodes_table = nwb_object.electrodes
+    else:
+        raise ValueError('nwb_object must be of type ElectricalSeries or NWBFile')
 
-    return [elect_idx for elect_idx, elect_id in enumerate(electrode_table_indices) if elect_id in electrode_ids]
+    return [elect_idx for elect_idx, elect_id in enumerate(electrodes_table.ids[:]) if elect_id in electrode_ids]
 
 
 def get_all_spatial_series(nwbf, verbose=False):

--- a/tests/test_nwb_helper_fn.py
+++ b/tests/test_nwb_helper_fn.py
@@ -1,0 +1,58 @@
+import datetime
+import pynwb
+import unittest
+
+from nwb_datajoint.common import get_electrode_indices
+
+
+class TestGetElectrodeIndices(unittest.TestCase):
+
+    def setUp(self):
+        self.nwbfile = pynwb.NWBFile(
+            session_description='session_description',
+            identifier='identifier',
+            session_start_time=datetime.datetime.now(datetime.timezone.utc),
+        )
+        dev = self.nwbfile.create_device(
+            name='device'
+        )
+        elec_group = self.nwbfile.create_electrode_group(
+            name='electrodes',
+            description='description',
+            location='location',
+            device=dev
+        )
+        for i in range(10):
+            self.nwbfile.add_electrode(
+                id=100+i,
+                x=0.0,
+                y=0.0,
+                z=0.0,
+                imp=-1.0,
+                location='location',
+                filtering='filtering',
+                group=elec_group
+            )
+
+        elecs_region = self.nwbfile.electrodes.create_region(
+            name='electrodes',
+            region=[2, 3, 4, 5],  # indices
+            description='description'
+        )
+
+        eseries = pynwb.ecephys.ElectricalSeries(
+            name='eseries',
+            data=[0, 1, 2],
+            timestamps=[0., 1., 2.],
+            electrodes=elecs_region
+        )
+        self.nwbfile.add_acquisition(eseries)
+
+    def test_nwbfile(self):
+        ret = get_electrode_indices(self.nwbfile, [102, 105])
+        assert ret == [2, 5]
+
+    def test_electrical_series(self):
+        eseries = self.nwbfile.acquisition['eseries']
+        ret = get_electrode_indices(eseries, [102, 105])
+        assert ret == [0, 3]


### PR DESCRIPTION
When `get_electrode_indices` was passed an `ElectricalSeries` object, the electrode row indices were being matched against the given electrode IDs instead of the IDs. This PR fixes that issue.

This also adds tests to ensure the function works and demonstrate the intended behavior.