### PR TITLE
Revert usage of get_data_interface, fix TaskEpoch not populating

### DIFF
--- a/src/nwb_datajoint/common/common_task.py
+++ b/src/nwb_datajoint/common/common_task.py
@@ -1,4 +1,5 @@
 import datajoint as dj
+import hdmf
 
 from .common_device import CameraDevice
 from .common_interval import IntervalList
@@ -55,7 +56,7 @@ class Task(dj.Manual):
     #     task_dict = dict()
     #     #search through he processing modules to see if we can find a behavior module. This should probably be a
     #     # general function
-    #     task_interface = get_data_interface(nwbf, 'task')
+    #     task_interface = get_data_interface(nwbf, 'task', hdmf.common.DynamicTable)
     #     if task_interface is not None:
     #         # check the datatype
     #         if task_interface.data_type == 'DynamicTable':
@@ -102,7 +103,7 @@ class TaskEpoch(dj.Imported):
         # TODO: change to new task structure
         for task_num in range(0, 10):
             task_str = 'task_' + str(task_num)
-            task = get_data_interface(nwbf, task_str)
+            task = get_data_interface(nwbf, task_str, hdmf.common.DynamicTable)
             if task is not None:
                 # check if the task is in the Task table and if not, add it
                 if len(((Task() & {'task_name': task.task_name[0]}).fetch())) == 0:

--- a/src/nwb_datajoint/common/nwb_helper_fn.py
+++ b/src/nwb_datajoint/common/nwb_helper_fn.py
@@ -62,9 +62,7 @@ def get_data_interface(nwbfile, data_interface_name, data_interface_class=pynwb.
     ret = []
     for module in nwbfile.processing.values():
         match = module.data_interfaces.get(data_interface_name, None)
-        #TODO figure out why Ryan put this isinstance in
-        #if match is not None and isinstance(match, data_interface_class):
-        if match is not None:
+        if match is not None and isinstance(match, data_interface_class):
             ret.append(match)
     if len(ret) > 1:
         warnings.warn(f"Multiple data interfaces with name '{data_interface_name}' and class {data_interface_class} "

--- a/src/nwb_datajoint/common/nwb_helper_fn.py
+++ b/src/nwb_datajoint/common/nwb_helper_fn.py
@@ -37,22 +37,23 @@ def close_nwb_files():
     __open_nwb_files.clear()
 
 
-def get_data_interface(nwbfile, data_interface_name, data_interface_class=pynwb.core.NWBDataInterface):
-    """Search for a specified data interface in the processing modules of an NWB file.
+def get_data_interface(nwbfile, data_interface_name, data_interface_class=None):
+    """Search for a specified NWBDataInterface or DynamicTable in the processing modules of an NWB file.
 
     Parameters
     ----------
     nwbfile : pynwb.NWBFile
         The NWB file object to search in.
     data_interface_name : str
-        The name of the NWBDataInterface to search for.
+        The name of the NWBDataInterface or DynamicTable to search for.
     data_interface_class : type, optional
-        The class (or superclass) of the NWBDataInterface to search for (default: pynwb.core.NWBDataInterface).
+        The class (or superclass) to search for. This argument helps to prevent accessing an object with the same
+        name but the incorrect type. Default: no restriction.
 
     Warns
     -----
     UserWarning
-        If multiple data interfaces with the matching name are found.
+        If multiple NWBDataInterface and DynamicTable objects with the matching name are found.
 
     Returns
     -------
@@ -62,11 +63,14 @@ def get_data_interface(nwbfile, data_interface_name, data_interface_class=pynwb.
     ret = []
     for module in nwbfile.processing.values():
         match = module.data_interfaces.get(data_interface_name, None)
-        if match is not None and isinstance(match, data_interface_class):
+        if match is not None:
+            if data_interface_class is not None and not isinstance(match, data_interface_class):
+                continue
             ret.append(match)
     if len(ret) > 1:
-        warnings.warn(f"Multiple data interfaces with name '{data_interface_name}' and class {data_interface_class} "
-                      f"found in NWBFile with identifier {nwbfile.identifier}. Using the first one found.")
+        warnings.warn(f"Multiple data interfaces with name '{data_interface_name}' "
+                      f"found in NWBFile with identifier {nwbfile.identifier}. Using the first one found. "
+                      "Use the data_interface_class argument to restrict the search.")
     if len(ret) >= 1:
         return ret[0]
     else:


### PR DESCRIPTION
This commit https://github.com/LorenFrankLab/nwb_datajoint/commit/e7574d41ce3ad46cbb294121fe2fc4766a3162c9 resolved #54. However, the `isinstance` check on `get_data_interface` is useful when different objects have a matching name but an incorrect type (especially considering across files from different labs). 

This PR reverts the above commit, adds documentation, and fixes how `get_data_interface` is called in `TaskEpoch` so that it is populated correctly.