### PR TITLE
Minor test improvements

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ sys.path.append(thisdir)
 
 
 global __PROCESS
+__PROCESS = None
 
 
 def pytest_addoption(parser):

--- a/tests/datajoint/_datajoint_server.py
+++ b/tests/datajoint/_datajoint_server.py
@@ -75,6 +75,7 @@ def kill_datajoint_server():
 
 
 def _wait_for_datajoint_server_to_start():
+    time.sleep(15)  # it takes a while to start the server
     timer = time.time()
     while True:
         try:


### PR DESCRIPTION
Initialize the internal `__PROCESS` variable so that if a test fails, another error is not triggered because `__PROCESS` is not initialized.

Also delay for 15 seconds testing whether the datajoint server is fully up.