### PR TITLE
Remove analog processing module from copied NWB file

### DIFF
--- a/src/nwb_datajoint/common/populate_all_common.py
+++ b/src/nwb_datajoint/common/populate_all_common.py
@@ -5,7 +5,7 @@ from .common_dio import DIOEvents
 # from .common_nwbfile import NwbfileKachery
 from .common_ephys import Electrode, ElectrodeGroup, Raw, SampleCount
 from .common_nwbfile import Nwbfile
-from .common_sensors import SensorData
+# from .common_sensors import SensorData
 from .common_session import ExperimenterList, Session
 from .common_task import TaskEpoch
 
@@ -31,8 +31,11 @@ def populate_all_common(nwb_file_name):
     SampleCount.populate(fp)
     print('Populate DIOEvents...')
     DIOEvents.populate(fp)
-    print('Populate SensorData')
-    SensorData.populate(fp)
+    # sensor data (from analog ProcessingModule) is temporarily removed from NWBFile
+    # to reduce file size while it is not being used. add it back in by commenting out
+    # the removal code in nwb_datajoint/data_import/insert_sessions.py when ready
+    # print('Populate SensorData')
+    # SensorData.populate(fp)
     print('Populate TaskEpochs')
     TaskEpoch.populate(fp)
     print('Populate StateScriptFile')

--- a/src/nwb_datajoint/data_import/insert_sessions.py
+++ b/src/nwb_datajoint/data_import/insert_sessions.py
@@ -63,6 +63,11 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
         for eseries in eseries_list:
             nwbf.acquisition.pop(eseries.name)
 
+        # pop off analog processing module
+        analog_processing = nwbf.processing.get('analog')
+        if analog_processing:
+            nwbf.processing.pop('analog')
+
         # export the new NWB file
         with pynwb.NWBHDF5IO(path=out_nwb_file_abs_path, mode='w', manager=input_io.manager) as export_io:
             export_io.export(input_io, nwbf)
@@ -72,6 +77,7 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
     with pynwb.NWBHDF5IO(path=nwb_file_abs_path, mode='r', load_namespaces=True) as input_io:
         nwbf_raw = input_io.read()
         eseries_list = get_raw_eseries(nwbf_raw)
+        analog_processing = nwbf_raw.processing.get('analog')
 
         with pynwb.NWBHDF5IO(path=out_nwb_file_abs_path, mode='a', manager=input_io.manager) as export_io:
             nwbf_export = export_io.read()
@@ -79,7 +85,10 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
             # add link to raw ephys ElectricalSeries in raw data file
             for eseries in eseries_list:
                 nwbf_export.add_acquisition(eseries)
-            nwbf_export.set_modified()  # workaround until the above sets modified=True on the file
+
+            # add link to processing module in raw data file
+            nwbf_export.add_processing_module(analog_processing)
+            nwbf_export.set_modified()
 
             export_io.write(nwbf_export)
 

--- a/src/nwb_datajoint/data_import/insert_sessions.py
+++ b/src/nwb_datajoint/data_import/insert_sessions.py
@@ -87,9 +87,10 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
                 nwbf_export.add_acquisition(eseries)
 
             # add link to processing module in raw data file
-            nwbf_export.add_processing_module(analog_processing)
-            nwbf_export.set_modified()
+            if analog_processing:
+                nwbf_export.add_processing_module(analog_processing)
 
+            nwbf_export.set_modified()
             export_io.write(nwbf_export)
 
     return out_nwb_file_abs_path


### PR DESCRIPTION
`insert_sessions` which calls `copy_nwb_link_raw_ephys` will now create a copy of the NWB file and link not only the raw ephys data but also the analog sensor data which is currently large and not being used. This also speeds up the copying process.

For example, if the raw data is 88 GB, then before this change, the copied file would be 16 GB. Now it is 4 GB.