### PR TITLE
Exclude invalid times as indicated by interval_list prior to spike sorting

### DIFF
--- a/src/nwb_datajoint/common/common_ephys.py
+++ b/src/nwb_datajoint/common/common_ephys.py
@@ -74,6 +74,11 @@ class ElectrodeGroup(dj.Imported):
                         break
             if 'probe_type' not in key:
                 key['probe_type'] = 'unknown-probe-type'
+            # Define target_hemisphere based on targeted x coordinate
+            if electrode_group.targeted_x >= 0:  # if positive or zero x coordinate
+                key["target_hemisphere"] = "right"  # define target location as right hemisphere
+            elif electrode_group.targeted_y < 0:  # if negative x coordinate
+                key["target_hemisphere"] = "left"  # define target location as left hemisphere
             self.insert1(key, skip_duplicates=True)
 
 

--- a/src/nwb_datajoint/common/common_ephys.py
+++ b/src/nwb_datajoint/common/common_ephys.py
@@ -76,9 +76,9 @@ class ElectrodeGroup(dj.Imported):
                 key['probe_type'] = 'unknown-probe-type'
             # Define target_hemisphere based on targeted x coordinate
             if electrode_group.targeted_x >= 0:  # if positive or zero x coordinate
-                key["target_hemisphere"] = "right"  # define target location as right hemisphere
-            elif electrode_group.targeted_y < 0:  # if negative x coordinate
-                key["target_hemisphere"] = "left"  # define target location as left hemisphere
+                key["target_hemisphere"] = "Right"  # define target location as right hemisphere
+            elif electrode_group.targeted_x < 0:  # if negative x coordinate
+                key["target_hemisphere"] = "Left"  # define target location as left hemisphere
             self.insert1(key, skip_duplicates=True)
 
 

--- a/src/nwb_datajoint/common/common_spikesorting.py
+++ b/src/nwb_datajoint/common/common_spikesorting.py
@@ -409,14 +409,14 @@ class SpikeSortingRecording(dj.Computed):
             # update the sort interval valid times to exclude the artifacts
             sort_interval_valid_times = interval_list_intersect(
                 sort_interval_valid_times, no_artifact_valid_times)
-            # exclude the invalid times
-            mask = np.full(recording.get_num_frames(), True, dtype='bool')
-            excluded_ind = interval_list_excludes_ind(
-                sort_interval_valid_times, recording_timestamps)
-            if len(excluded_ind) > 0:
-                mask[interval_list_excludes_ind(
-                    sort_interval_valid_times, recording_timestamps)] = False
-            recording = st.preprocessing.mask(recording, mask)
+        # exclude the invalid times
+        mask = np.full(recording.get_num_frames(), True, dtype='bool')
+        excluded_ind = interval_list_excludes_ind(
+            sort_interval_valid_times, recording_timestamps)
+        if len(excluded_ind) > 0:
+            mask[interval_list_excludes_ind(
+                sort_interval_valid_times, recording_timestamps)] = False
+        recording = st.preprocessing.mask(recording, mask)
 
         #add the sort_interval_valid_times as an interval list
         tmp_key = {}

--- a/src/nwb_datajoint/common/common_spikesorting.py
+++ b/src/nwb_datajoint/common/common_spikesorting.py
@@ -409,14 +409,14 @@ class SpikeSortingRecording(dj.Computed):
             # update the sort interval valid times to exclude the artifacts
             sort_interval_valid_times = interval_list_intersect(
                 sort_interval_valid_times, no_artifact_valid_times)
-        # exclude the invalid times
-        mask = np.full(recording.get_num_frames(), True, dtype='bool')
-        excluded_ind = interval_list_excludes_ind(
-            sort_interval_valid_times, recording_timestamps)
-        if len(excluded_ind) > 0:
-            mask[interval_list_excludes_ind(
-                sort_interval_valid_times, recording_timestamps)] = False
-        recording = st.preprocessing.mask(recording, mask)
+            # exclude the invalid times
+            mask = np.full(recording.get_num_frames(), True, dtype='bool')
+            excluded_ind = interval_list_excludes_ind(
+                sort_interval_valid_times, recording_timestamps)
+            if len(excluded_ind) > 0:
+                mask[interval_list_excludes_ind(
+                    sort_interval_valid_times, recording_timestamps)] = False
+            recording = st.preprocessing.mask(recording, mask)
 
         #add the sort_interval_valid_times as an interval list
         tmp_key = {}

--- a/src/nwb_datajoint/common/common_spikesorting.py
+++ b/src/nwb_datajoint/common/common_spikesorting.py
@@ -342,7 +342,6 @@ class SpikeSortingArtifactDetectionParameters(dj.Manual):
 
         half_window_points = np.round(
             recording.get_sampling_frequency() * 1000 * zero_window_len / 2)
-        nelect_above = np.round(proportion_above_thresh * data.shape[0])
         # get the data traces
         data = recording.get_traces()
 
@@ -410,14 +409,14 @@ class SpikeSortingRecording(dj.Computed):
             # update the sort interval valid times to exclude the artifacts
             sort_interval_valid_times = interval_list_intersect(
                 sort_interval_valid_times, no_artifact_valid_times)
-            # exclude the invalid times
-            mask = np.full(recording.get_num_frames(), True, dtype='bool')
-            excluded_ind = interval_list_excludes_ind(
-                sort_interval_valid_times, recording_timestamps)
-            if len(excluded_ind) > 0:
-                mask[interval_list_excludes_ind(
-                    sort_interval_valid_times, recording_timestamps)] = False
-            recording = st.preprocessing.mask(recording, mask)
+        # exclude the invalid times
+        mask = np.full(recording.get_num_frames(), True, dtype='bool')
+        excluded_ind = interval_list_excludes_ind(
+            sort_interval_valid_times, recording_timestamps)
+        if len(excluded_ind) > 0:
+            mask[interval_list_excludes_ind(
+                sort_interval_valid_times, recording_timestamps)] = False
+        recording = st.preprocessing.mask(recording, mask)
 
         #add the sort_interval_valid_times as an interval list
         tmp_key = {}

--- a/src/nwb_datajoint/common/common_task.py
+++ b/src/nwb_datajoint/common/common_task.py
@@ -82,6 +82,7 @@ class TaskEpoch(dj.Imported):
      -> Task
      -> CameraDevice
      -> IntervalList
+     task_environment='' : varchar(200)  # the environment the animal was in
      """
 
     def make(self, key):
@@ -123,6 +124,11 @@ class TaskEpoch(dj.Imported):
                 # Users should define more restrictive intervals as required for analyses
                 session_intervals = (IntervalList() & {'nwb_file_name': nwb_file_name}).fetch(
                     'interval_list_name')
+                # Add task environment
+                try:
+                    key["task_environment"] = task.task_environment[0]
+                except Exception:
+                    key["task_environment"] = 'none'
                 for epoch in task.task_epochs[0]:
                     key['epoch'] = epoch
                     target_interval = str(epoch).zfill(2)


### PR DESCRIPTION
This change excludes invalid times as indicated by the interval_list associated with a spike sorting recording, prior to spike sorting. This was an intended use of the interval_list per @lfrank.