### PR TITLE
Fix position imports

### DIFF
--- a/src/nwb_datajoint/common/__init__.py
+++ b/src/nwb_datajoint/common/__init__.py
@@ -19,6 +19,8 @@ from .common_interval import (IntervalList, SortInterval,
 from .common_lab import Institution, Lab, LabMember, LabTeam
 from .common_nwbfile import (AnalysisNwbfile, AnalysisNwbfileKachery, Nwbfile,
                              NwbfileKachery)
+from .common_position import (PositionInfoParameters, IntervalPositionInfoSelection, IntervalPositionInfo, LinearizationParameters, 
+                              TrackGraph, IntervalLinearizationSelection, IntervalLinearizedPosition, PositionVideo)
 from .common_region import BrainRegion
 from .common_sensors import SensorData
 from .common_session import ExperimenterList, Session

--- a/src/nwb_datajoint/common/__init__.py
+++ b/src/nwb_datajoint/common/__init__.py
@@ -19,8 +19,6 @@ from .common_interval import (IntervalList, SortInterval,
 from .common_lab import Institution, Lab, LabMember, LabTeam
 from .common_nwbfile import (AnalysisNwbfile, AnalysisNwbfileKachery, Nwbfile,
                              NwbfileKachery)
-from .common_position import (PositionInfoParameters, IntervalPositionInfoSelection, IntervalPositionInfo, LinearizationParameters, 
-                              TrackGraph, IntervalLinearizationSelection, IntervalLinearizedPosition, PositionVideo)
 from .common_region import BrainRegion
 from .common_sensors import SensorData
 from .common_session import ExperimenterList, Session

--- a/src/nwb_datajoint/common/common_position.py
+++ b/src/nwb_datajoint/common/common_position.py
@@ -22,6 +22,7 @@ from track_linearization import (get_linearized_position, make_track_graph,
                                  plot_graph_as_1D, plot_track_graph)
 
 from .common_interval import IntervalList
+from .common_nwbfile import AnalysisNwbfile
 
 schema = dj.schema('common_position')
 
@@ -57,7 +58,7 @@ class IntervalPositionInfo(dj.Computed):
     definition = """
     -> IntervalPositionInfoSelection
     ---
-    -> nd.common.common_nwbfile.AnalysisNwbfile
+    -> AnalysisNwbfile
     head_position_object_id : varchar(40)
     head_orientation_object_id : varchar(40)
     head_velocity_object_id : varchar(40)
@@ -65,7 +66,7 @@ class IntervalPositionInfo(dj.Computed):
 
     def make(self, key):
         print(f'Computing position for: {key}')
-        key['analysis_file_name'] = nd.common.common_nwbfile.AnalysisNwbfile().create(
+        key['analysis_file_name'] = AnalysisNwbfile().create(
             key['nwb_file_name'])
         raw_position = (nd.common.common_behav.RawPosition() &
                         {'nwb_file_name': key['nwb_file_name'],
@@ -134,7 +135,7 @@ class IntervalPositionInfo(dj.Computed):
             pass
 
         # Insert into analysis nwb file
-        nwb_analysis_file = nd.common.common_nwbfile.AnalysisNwbfile()
+        nwb_analysis_file = AnalysisNwbfile()
 
         key['head_position_object_id'] = nwb_analysis_file.add_nwb_object(
             key['analysis_file_name'], head_position)
@@ -143,7 +144,7 @@ class IntervalPositionInfo(dj.Computed):
         key['head_velocity_object_id'] = nwb_analysis_file.add_nwb_object(
             key['analysis_file_name'], head_velocity)
 
-        nd.common.common_nwbfile.AnalysisNwbfile().add(
+        AnalysisNwbfile().add(
             key['nwb_file_name'], key['analysis_file_name'])
 
         self.insert1(key)
@@ -295,7 +296,7 @@ class IntervalPositionInfo(dj.Computed):
 
     def fetch_nwb(self, *attrs, **kwargs):
         return fetch_nwb(self,
-                         (nd.common.common_nwbfile.AnalysisNwbfile,
+                         (AnalysisNwbfile,
                           'analysis_file_abs_path'),
                          *attrs, **kwargs)
 
@@ -388,14 +389,14 @@ class IntervalLinearizedPosition(dj.Computed):
     definition = """
     -> IntervalLinearizationSelection
     ---
-    -> nd.common.common_nwbfile.AnalysisNwbfile
+    -> AnalysisNwbfile
     linearized_position_object_id : varchar(40)
     """
 
     def make(self, key):
         print(f'Computing linear position for: {key}')
 
-        key['analysis_file_name'] = nd.common.common_nwbfile.AnalysisNwbfile().create(
+        key['analysis_file_name'] = AnalysisNwbfile().create(
             key['nwb_file_name'])
 
         position_nwb = (
@@ -437,7 +438,7 @@ class IntervalLinearizedPosition(dj.Computed):
         linear_position_df['time'] = time
 
         # Insert into analysis nwb file
-        nwb_analysis_file = nd.common.common_nwbfile.AnalysisNwbfile()
+        nwb_analysis_file = AnalysisNwbfile()
 
         key['linearized_position_object_id'] = nwb_analysis_file.add_nwb_object(
             analysis_file_name=key['analysis_file_name'],
@@ -451,7 +452,7 @@ class IntervalLinearizedPosition(dj.Computed):
         self.insert1(key)
 
     def fetch_nwb(self, *attrs, **kwargs):
-        return fetch_nwb(self, (nd.common.common_nwbfile.AnalysisNwbfile, 'analysis_file_abs_path'),
+        return fetch_nwb(self, (AnalysisNwbfile, 'analysis_file_abs_path'),
                          *attrs, **kwargs)
 
     def fetch1_dataframe(self):

--- a/src/nwb_datajoint/common/common_position.py
+++ b/src/nwb_datajoint/common/common_position.py
@@ -21,6 +21,7 @@ from tqdm import tqdm_notebook as tqdm
 from track_linearization import (get_linearized_position, make_track_graph,
                                  plot_graph_as_1D, plot_track_graph)
 
+from .common_behav import RawPosition
 from .common_interval import IntervalList
 from .common_nwbfile import AnalysisNwbfile
 
@@ -68,7 +69,7 @@ class IntervalPositionInfo(dj.Computed):
         print(f'Computing position for: {key}')
         key['analysis_file_name'] = AnalysisNwbfile().create(
             key['nwb_file_name'])
-        raw_position = (nd.common.common_behav.RawPosition() &
+        raw_position = (RawPosition() &
                         {'nwb_file_name': key['nwb_file_name'],
                          'interval_list_name': key['interval_list_name']
                          }).fetch_nwb()[0]

--- a/src/nwb_datajoint/common/common_position.py
+++ b/src/nwb_datajoint/common/common_position.py
@@ -45,7 +45,7 @@ class PositionInfoParameters(dj.Lookup):
 class IntervalPositionInfoSelection(dj.Lookup):
     definition = """
     -> PositionInfoParameters
-    -> nd.common.IntervalList
+    -> nd.common.common_interval.IntervalList
     ---
     """
 
@@ -55,7 +55,7 @@ class IntervalPositionInfo(dj.Computed):
     definition = """
     -> IntervalPositionInfoSelection
     ---
-    -> nd.common.AnalysisNwbfile
+    -> nd.common.common_nwbfile.AnalysisNwbfile
     head_position_object_id : varchar(40)
     head_orientation_object_id : varchar(40)
     head_velocity_object_id : varchar(40)
@@ -63,9 +63,9 @@ class IntervalPositionInfo(dj.Computed):
 
     def make(self, key):
         print(f'Computing position for: {key}')
-        key['analysis_file_name'] = nd.common.AnalysisNwbfile().create(
+        key['analysis_file_name'] = nd.common.common_nwbfile.AnalysisNwbfile().create(
             key['nwb_file_name'])
-        raw_position = (nd.common.RawPosition() &
+        raw_position = (nd.common.common_behav.RawPosition() &
                         {'nwb_file_name': key['nwb_file_name'],
                          'interval_list_name': key['interval_list_name']
                          }).fetch_nwb()[0]
@@ -132,7 +132,7 @@ class IntervalPositionInfo(dj.Computed):
             pass
 
         # Insert into analysis nwb file
-        nwb_analysis_file = nd.common.AnalysisNwbfile()
+        nwb_analysis_file = nd.common.common_nwbfile.AnalysisNwbfile()
 
         key['head_position_object_id'] = nwb_analysis_file.add_nwb_object(
             key['analysis_file_name'], head_position)
@@ -141,7 +141,7 @@ class IntervalPositionInfo(dj.Computed):
         key['head_velocity_object_id'] = nwb_analysis_file.add_nwb_object(
             key['analysis_file_name'], head_velocity)
 
-        nd.common.AnalysisNwbfile().add(
+        nd.common.common_nwbfile.AnalysisNwbfile().add(
             key['nwb_file_name'], key['analysis_file_name'])
 
         self.insert1(key)
@@ -293,7 +293,8 @@ class IntervalPositionInfo(dj.Computed):
 
     def fetch_nwb(self, *attrs, **kwargs):
         return fetch_nwb(self,
-                         (nd.common.AnalysisNwbfile, 'analysis_file_abs_path'),
+                         (nd.common.common_nwbfile.AnalysisNwbfile,
+                          'analysis_file_abs_path'),
                          *attrs, **kwargs)
 
     def fetch1_dataframe(self):
@@ -385,14 +386,14 @@ class IntervalLinearizedPosition(dj.Computed):
     definition = """
     -> IntervalLinearizationSelection
     ---
-    -> nd.common.AnalysisNwbfile
+    -> nd.common.common_nwbfile.AnalysisNwbfile
     linearized_position_object_id : varchar(40)
     """
 
     def make(self, key):
         print(f'Computing linear position for: {key}')
 
-        key['analysis_file_name'] = nd.common.AnalysisNwbfile().create(
+        key['analysis_file_name'] = nd.common.common_nwbfile.AnalysisNwbfile().create(
             key['nwb_file_name'])
 
         position_nwb = (
@@ -434,7 +435,7 @@ class IntervalLinearizedPosition(dj.Computed):
         linear_position_df['time'] = time
 
         # Insert into analysis nwb file
-        nwb_analysis_file = nd.common.AnalysisNwbfile()
+        nwb_analysis_file = nd.common.common_nwbfile.AnalysisNwbfile()
 
         key['linearized_position_object_id'] = nwb_analysis_file.add_nwb_object(
             analysis_file_name=key['analysis_file_name'],
@@ -448,7 +449,7 @@ class IntervalLinearizedPosition(dj.Computed):
         self.insert1(key)
 
     def fetch_nwb(self, *attrs, **kwargs):
-        return fetch_nwb(self, (nd.common.AnalysisNwbfile, 'analysis_file_abs_path'),
+        return fetch_nwb(self, (nd.common.common_nwbfile.AnalysisNwbfile, 'analysis_file_abs_path'),
                          *attrs, **kwargs)
 
     def fetch1_dataframe(self):

--- a/src/nwb_datajoint/common/common_position.py
+++ b/src/nwb_datajoint/common/common_position.py
@@ -579,7 +579,7 @@ class PositionVideo(dj.Computed):
         M_TO_CM = 100
 
         print('Loading position data...')
-        raw_position_df = (nd.common.common_behav.RawPosition() & {
+        raw_position_df = (RawPosition() & {
                            'nwb_file_name': key['nwb_file_name'],
                            'interval_list_name': key['interval_list_name']}
                            ).fetch1_dataframe()

--- a/src/nwb_datajoint/common/common_position.py
+++ b/src/nwb_datajoint/common/common_position.py
@@ -21,6 +21,8 @@ from tqdm import tqdm_notebook as tqdm
 from track_linearization import (get_linearized_position, make_track_graph,
                                  plot_graph_as_1D, plot_track_graph)
 
+from .common_interval import IntervalList
+
 schema = dj.schema('common_position')
 
 
@@ -45,7 +47,7 @@ class PositionInfoParameters(dj.Lookup):
 class IntervalPositionInfoSelection(dj.Lookup):
     definition = """
     -> PositionInfoParameters
-    -> nd.common.common_interval.IntervalList
+    -> IntervalList
     ---
     """
 


### PR DESCRIPTION
Imports into the top level of nwb_datajoint.common from common_position were circular, creating a foreign key reference error. This PR removes the circularity within the common_position module and therefore allows imports into the top level. All tests should be passing now.