### PR TITLE
Dpg fix

### DIFF
--- a/src/nwb_datajoint/common/common_spikesorting.py
+++ b/src/nwb_datajoint/common/common_spikesorting.py
@@ -1400,7 +1400,8 @@ class AutomaticCuration(dj.Computed):
                         # get the noise rejection parameters
                         noise_reject_param = acpd['noise_reject_param']
                         #TODO write noise/ rejection code
-        # metrics = None
+        else:
+            metrics = None
         # Store the sorting with metrics in the NWB file and update the metrics in the workspace
         sort_interval_list_name = (SpikeSortingRecording & key).fetch1('sort_interval_list_name')
 

--- a/src/nwb_datajoint/common/common_spikesorting.py
+++ b/src/nwb_datajoint/common/common_spikesorting.py
@@ -1400,7 +1400,7 @@ class AutomaticCuration(dj.Computed):
                         # get the noise rejection parameters
                         noise_reject_param = acpd['noise_reject_param']
                         #TODO write noise/ rejection code
-        metrics = None
+        # metrics = None
         # Store the sorting with metrics in the NWB file and update the metrics in the workspace
         sort_interval_list_name = (SpikeSortingRecording & key).fetch1('sort_interval_list_name')
 


### PR DESCRIPTION
Fixes an indentation error, so metrics are not always set to none in Automatic Curation. Still allows for metric calculation to be bypassed during table population if no metrics are in automatic curation parameter dict. 