### PR TITLE
Fix formatting, show warning instead of raise error

### DIFF
--- a/src/nwb_datajoint/common/common_filter.py
+++ b/src/nwb_datajoint/common/common_filter.py
@@ -6,7 +6,7 @@ import numpy as np
 import pynwb
 import scipy.signal as signal
 import psutil
-import sys
+import warnings
 
 from .nwb_helper_fn import get_electrode_indices
 
@@ -16,17 +16,17 @@ schema = dj.schema('common_filter')
 @schema
 class FirFilter(dj.Manual):
     definition = """
-    filter_name: varchar(80)    # descriptive name of this filter
-    filter_sampling_rate: int       # sampling rate for this filter
+    filter_name: varchar(200)        # descriptive name of this filter
+    filter_sampling_rate: int        # sampling rate for this filter
     ---
-    filter_type: enum('lowpass', 'highpass', 'bandpass')
-    filter_low_stop=0: float         # lowest frequency for stop band for low frequency side of filter
-    filter_low_pass=0: float         # lowest frequency for pass band of low frequency side of filter
-    filter_high_pass=0: float         # highest frequency for pass band for high frequency side of filter
-    filter_high_stop=0: float         # highest frequency for stop band of high frequency side of filter
-    filter_comments: varchar(255)   # comments about the filter
-    filter_band_edges: blob         # numpy array containing the filter bands (redundant with individual parameters)
-    filter_coeff: blob               # numpy array containing the filter coefficients
+    filter_type: enum("lowpass", "highpass", "bandpass")
+    filter_low_stop = 0: float         # lowest frequency for stop band for low frequency side of filter
+    filter_low_pass = 0: float         # lowest frequency for pass band of low frequency side of filter
+    filter_high_pass = 0: float        # highest frequency for pass band for high frequency side of filter
+    filter_high_stop = 0: float        # highest frequency for stop band of high frequency side of filter
+    filter_comments: varchar(2000)     # comments about the filter
+    filter_band_edges: blob            # numpy array containing the filter bands (redundant with individual parameters)
+    filter_coeff: blob                 # numpy array containing the filter coefficients
     """
 
     def add_filter(self, filter_name, fs, filter_type, band_edges, comments=''):
@@ -172,26 +172,27 @@ class FirFilter(dj.Manual):
         filter_delay = self.calc_filter_delay(filter_coeff)
         for a_start, a_stop in valid_times:
             if a_start < timestamps_on_disk[0]:
-                raise Warning('Interval start time %f is smaller than first timestamp %f, using first timestamp instead' % (
-                    a_start, timestamps_on_disk[0]))
+                warnings.warn(f'Interval start time {a_start} is smaller than first timestamp {timestamps_on_disk[0]}, '
+                              'using first timestamp instead')
                 a_start = timestamps_on_disk[0]
             if a_stop > timestamps_on_disk[-1]:
-                raise Warning('Interval stop time %f is larger than last timestamp %f, using last timestamp instead' % (
-                    a_stop, timestamps_on_disk[-1]))
+                warnings.warn(f'Interval stop time {a_stop} is larger than last timestamp {timestamps_on_disk[-1]}, '
+                              'using last timestamp instead')
                 a_stop = timestamps_on_disk[-1]
             frm, to = np.searchsorted(timestamps_on_disk, (a_start, a_stop))
             if to > n_samples:
                 to = n_samples
             indices.append((frm, to))
-            shape, dtype = gsp.filter_data_fir(data_on_disk,
-                                            filter_coeff,
-                                            axis=time_axis,
-                                            input_index_bounds=[frm, to-1],
-                                            output_index_bounds=[
-                                                filter_delay, filter_delay + to - frm],
-                                            describe_dims=True,
-                                            ds=decimation,
-                                            input_dim_restrictions=input_dim_restrictions)
+            shape, dtype = gsp.filter_data_fir(
+                data_on_disk,
+                filter_coeff,
+                axis=time_axis,
+                input_index_bounds=[frm, to-1],
+                output_index_bounds=[filter_delay, filter_delay + to - frm],
+                describe_dims=True,
+                ds=decimation,
+                input_dim_restrictions=input_dim_restrictions
+            )
             output_offsets.append(output_offsets[-1] + shape[time_axis])
             output_shape_list[time_axis] += shape[time_axis]
 
@@ -204,11 +205,12 @@ class FirFilter(dj.Manual):
             electrode_table_region = nwbf.create_electrode_table_region(
                 elect_ind, 'filtered electrode table')
             eseries_name = 'filtered data'
-            es = pynwb.ecephys.ElectricalSeries(name=eseries_name,
-                                                data=np.empty(
-                                                    tuple(output_shape_list), dtype=data_dtype),
-                                                electrodes=electrode_table_region,
-                                                timestamps=np.empty(output_shape_list[time_axis]))
+            es = pynwb.ecephys.ElectricalSeries(
+                name=eseries_name,
+                data=np.empty(tuple(output_shape_list), dtype=data_dtype),
+                electrodes=electrode_table_region,
+                timestamps=np.empty(output_shape_list[time_axis])
+            )
             # Add the electrical series to the scratch area
             nwbf.add_scratch(es)
             io.write(nwbf)
@@ -223,14 +225,13 @@ class FirFilter(dj.Manual):
                 # Filter and write the output dataset
                 ts_offset = 0
 
-
                 print('Filtering data')
                 for ii, (start, stop) in enumerate(indices):
                     # calculate the size of the timestamps and the data and determine whether they
                     # can be loaded into < 90% of available RAM
                     mem = psutil.virtual_memory()
                     interval_samples = stop-start
-                    if interval_samples * (timestamp_size +  n_electrodes*data_size) < 0.9 * mem.available:
+                    if interval_samples * (timestamp_size + n_electrodes*data_size) < 0.9 * mem.available:
                         print(f'Interval {ii}: loading data into memory')
                         timestamps = np.asarray(timestamps_on_disk[start:stop], dtype=timestamp_dtype)
                         if time_axis == 0:
@@ -238,8 +239,7 @@ class FirFilter(dj.Manual):
                         else:
                             data = np.asarray(data_on_disk[:, start:stop], dtype=data_dtype)
                         extracted_ts = timestamps[0::decimation]
-                        new_timestamps[ts_offset:ts_offset +
-                                len(extracted_ts)] = extracted_ts
+                        new_timestamps[ts_offset:ts_offset + len(extracted_ts)] = extracted_ts
                         ts_offset += len(extracted_ts)
                         # filter the data
                         gsp.filter_data_fir(data,
@@ -257,8 +257,7 @@ class FirFilter(dj.Manual):
                         data = data_on_disk
                         timestamps = timestamps_on_disk
                         extracted_ts = timestamps[start:stop:decimation]
-                        new_timestamps[ts_offset:ts_offset +
-                                    len(extracted_ts)] = extracted_ts
+                        new_timestamps[ts_offset:ts_offset + len(extracted_ts)] = extracted_ts
                         ts_offset += len(extracted_ts)
                         # filter the data
                         gsp.filter_data_fir(data,
@@ -304,10 +303,12 @@ class FirFilter(dj.Manual):
         filter_delay = self.calc_filter_delay(filter_coeff)
         for a_start, a_stop in valid_times:
             if a_start < timestamps[0]:
-                print(f'Interval start time {a_start} is smaller than first timestamp {timestamps[0]}, using first timestamp instead')
+                print(f'Interval start time {a_start} is smaller than first timestamp '
+                      f'{timestamps[0]}, using first timestamp instead')
                 a_start = timestamps[0]
             if a_stop > timestamps[-1]:
-                print(f'Interval stop time {a_stop} is larger than last timestamp {timestamps[-1]}, using last timestamp instead')
+                print(f'Interval stop time {a_stop} is larger than last timestamp '
+                      f'{timestamps[-1]}, using last timestamp instead')
                 a_stop = timestamps[-1]
             frm, to = np.searchsorted(timestamps, (a_start, a_stop))
             if to > n_samples:
@@ -340,7 +341,7 @@ class FirFilter(dj.Manual):
         for ii, (start, stop) in enumerate(indices):
             extracted_ts = timestamps[start:stop:decimation]
 
-            #print(f"Diffs {np.diff(extracted_ts)}")
+            # print(f"Diffs {np.diff(extracted_ts)}")
             new_timestamps[ts_offset:ts_offset +
                            len(extracted_ts)] = extracted_ts
             ts_offset += len(extracted_ts)

--- a/src/nwb_datajoint/common/common_filter.py
+++ b/src/nwb_datajoint/common/common_filter.py
@@ -16,17 +16,17 @@ schema = dj.schema('common_filter')
 @schema
 class FirFilter(dj.Manual):
     definition = """
-    filter_name: varchar(200)        # descriptive name of this filter
-    filter_sampling_rate: int        # sampling rate for this filter
+    filter_name: varchar(80)    # descriptive name of this filter
+    filter_sampling_rate: int       # sampling rate for this filter
     ---
-    filter_type: enum("lowpass", "highpass", "bandpass")
-    filter_low_stop = 0: float         # lowest frequency for stop band for low frequency side of filter
-    filter_low_pass = 0: float         # lowest frequency for pass band of low frequency side of filter
-    filter_high_pass = 0: float        # highest frequency for pass band for high frequency side of filter
-    filter_high_stop = 0: float        # highest frequency for stop band of high frequency side of filter
-    filter_comments: varchar(2000)     # comments about the filter
-    filter_band_edges: blob            # numpy array containing the filter bands (redundant with individual parameters)
-    filter_coeff: blob                 # numpy array containing the filter coefficients
+    filter_type: enum('lowpass', 'highpass', 'bandpass')
+    filter_low_stop=0: float         # lowest frequency for stop band for low frequency side of filter
+    filter_low_pass=0: float         # lowest frequency for pass band of low frequency side of filter
+    filter_high_pass=0: float         # highest frequency for pass band for high frequency side of filter
+    filter_high_stop=0: float         # highest frequency for stop band of high frequency side of filter
+    filter_comments: varchar(255)   # comments about the filter
+    filter_band_edges: blob         # numpy array containing the filter bands (redundant with individual parameters)
+    filter_coeff: blob               # numpy array containing the filter coefficients
     """
 
     def add_filter(self, filter_name, fs, filter_type, band_edges, comments=''):


### PR DESCRIPTION
The code `raise Warning(...)` will raise an error that stops execution. This appears not to be the intended behavior. The correct code to show a warning is `warnings.warn(...)`.

I also made minor formatting changes to `common_filter.py` so that it is compliant with PEP8 code style.