### PR TITLE
use stat. codes for permissions

### DIFF
--- a/src/nwb_datajoint/common/common_nwbfile.py
+++ b/src/nwb_datajoint/common/common_nwbfile.py
@@ -154,7 +154,7 @@ class AnalysisNwbfile(dj.Manual):
                 export_io.export(io, nwbf)
 
         # change the permissions to only allow owner to write
-        permissions = stat.S_IRUSR | stat.IWUSR | stat.S_IRGRP | stat.IROTH
+        permissions = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
         os.chmod(analysis_file_abs_path, permissions)
 
         return analysis_file_name

--- a/src/nwb_datajoint/common/common_nwbfile.py
+++ b/src/nwb_datajoint/common/common_nwbfile.py
@@ -207,6 +207,9 @@ class AnalysisNwbfile(dj.Manual):
             with pynwb.NWBHDF5IO(path=analysis_file_abs_path, mode='w', manager=io.manager) as export_io:
                 export_io.export(io, nwbf)
 
+        # change the permissions to only allow owner to write
+        os.fchmod(analysis_file_abs_path, 644)
+
         return analysis_file_name
 
     def add(self, nwb_file_name, analysis_file_name):

--- a/src/nwb_datajoint/common/common_nwbfile.py
+++ b/src/nwb_datajoint/common/common_nwbfile.py
@@ -154,7 +154,7 @@ class AnalysisNwbfile(dj.Manual):
                 export_io.export(io, nwbf)
 
         # change the permissions to only allow owner to write
-        permissions = stat.S_IRUSR | stat.IWUSER | stat.S_IRGRP | stat.IROTH
+        permissions = stat.S_IRUSR | stat.IWUSR | stat.S_IRGRP | stat.IROTH
         os.chmod(analysis_file_abs_path, permissions)
 
         return analysis_file_name

--- a/src/nwb_datajoint/common/common_nwbfile.py
+++ b/src/nwb_datajoint/common/common_nwbfile.py
@@ -152,7 +152,10 @@ class AnalysisNwbfile(dj.Manual):
             with pynwb.NWBHDF5IO(path=analysis_file_abs_path, mode='w', manager=io.manager) as export_io:
                 export_io.export(io, nwbf)
 
-        return analysis_file_name
+            # change the permissions to only allow owner to write
+            os.fchmod(analysis_file_abs_path, 644)
+
+            return analysis_file_name
 
     @classmethod
     def __get_new_file_name(cls, nwb_file_name):
@@ -206,9 +209,6 @@ class AnalysisNwbfile(dj.Manual):
             # export the new NWB file
             with pynwb.NWBHDF5IO(path=analysis_file_abs_path, mode='w', manager=io.manager) as export_io:
                 export_io.export(io, nwbf)
-
-        # change the permissions to only allow owner to write
-        os.fchmod(analysis_file_abs_path, 644)
 
         return analysis_file_name
 

--- a/src/nwb_datajoint/common/common_nwbfile.py
+++ b/src/nwb_datajoint/common/common_nwbfile.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import pathlib
 import random
 import string
@@ -153,7 +154,8 @@ class AnalysisNwbfile(dj.Manual):
                 export_io.export(io, nwbf)
 
         # change the permissions to only allow owner to write
-        os.fchmod(analysis_file_abs_path, 644)
+        permissions = stat.S_IRWXU or stat.S_IRGRP or stat.IROTH
+        os.chmod(analysis_file_abs_path, permissions)
 
         return analysis_file_name
 

--- a/src/nwb_datajoint/common/common_nwbfile.py
+++ b/src/nwb_datajoint/common/common_nwbfile.py
@@ -152,10 +152,10 @@ class AnalysisNwbfile(dj.Manual):
             with pynwb.NWBHDF5IO(path=analysis_file_abs_path, mode='w', manager=io.manager) as export_io:
                 export_io.export(io, nwbf)
 
-            # change the permissions to only allow owner to write
-            os.fchmod(analysis_file_abs_path, 644)
+        # change the permissions to only allow owner to write
+        os.fchmod(analysis_file_abs_path, 644)
 
-            return analysis_file_name
+        return analysis_file_name
 
     @classmethod
     def __get_new_file_name(cls, nwb_file_name):

--- a/src/nwb_datajoint/common/common_nwbfile.py
+++ b/src/nwb_datajoint/common/common_nwbfile.py
@@ -154,7 +154,7 @@ class AnalysisNwbfile(dj.Manual):
                 export_io.export(io, nwbf)
 
         # change the permissions to only allow owner to write
-        permissions = stat.S_IRWXU or stat.S_IRGRP or stat.IROTH
+        permissions = stat.S_IRUSR | stat.IWUSER | stat.S_IRGRP | stat.IROTH
         os.chmod(analysis_file_abs_path, permissions)
 
         return analysis_file_name

--- a/src/nwb_datajoint/data_import/insert_sessions.py
+++ b/src/nwb_datajoint/data_import/insert_sessions.py
@@ -93,4 +93,7 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
             nwbf_export.set_modified()
             export_io.write(nwbf_export)
 
+    # change the permissions to only allow owner to write
+    os.fchmod(out_nwb_file_abs_path, 644)
+
     return out_nwb_file_abs_path

--- a/src/nwb_datajoint/data_import/insert_sessions.py
+++ b/src/nwb_datajoint/data_import/insert_sessions.py
@@ -95,7 +95,7 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
             export_io.write(nwbf_export)
 
      # change the permissions to only allow owner to write
-    permissions = stat.S_IRUSR | stat.IWUSER | stat.S_IRGRP | stat.IROTH
+    permissions = stat.S_IRUSR | stat.IWUSR | stat.S_IRGRP | stat.IROTH
     os.chmod(out_nwb_file_abs_path, permissions)
 
     return out_nwb_file_abs_path

--- a/src/nwb_datajoint/data_import/insert_sessions.py
+++ b/src/nwb_datajoint/data_import/insert_sessions.py
@@ -95,7 +95,7 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
             export_io.write(nwbf_export)
 
      # change the permissions to only allow owner to write
-    permissions = stat.S_IRUSR | stat.IWUSR | stat.S_IRGRP | stat.IROTH
+    permissions = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
     os.chmod(out_nwb_file_abs_path, permissions)
 
     return out_nwb_file_abs_path

--- a/src/nwb_datajoint/data_import/insert_sessions.py
+++ b/src/nwb_datajoint/data_import/insert_sessions.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import warnings
 
 import pynwb
@@ -93,7 +94,8 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
             nwbf_export.set_modified()
             export_io.write(nwbf_export)
 
-    # change the permissions to only allow owner to write
-    os.fchmod(out_nwb_file_abs_path, 644)
+     # change the permissions to only allow owner to write
+    permissions = stat.S_IRWXU or stat.S_IRGRP or stat.IROTH
+    os.chmod(out_nwb_file_abs_path, permissions)
 
     return out_nwb_file_abs_path

--- a/src/nwb_datajoint/data_import/insert_sessions.py
+++ b/src/nwb_datajoint/data_import/insert_sessions.py
@@ -95,7 +95,7 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
             export_io.write(nwbf_export)
 
      # change the permissions to only allow owner to write
-    permissions = stat.S_IRWXU or stat.S_IRGRP or stat.IROTH
+    permissions = stat.S_IRUSR | stat.IWUSER | stat.S_IRGRP | stat.IROTH
     os.chmod(out_nwb_file_abs_path, permissions)
 
     return out_nwb_file_abs_path


### PR DESCRIPTION
This should set the permissions on the _.nwb file and AnalysisNWBFiles to 644 to make sure that only the user can delete them. I have not yet tested this, however. 