### PR TITLE
Move lab team to primary key for `SpikeSortingRecordingSelection`

### DIFF
--- a/src/nwb_datajoint/common/common_spikesorting.py
+++ b/src/nwb_datajoint/common/common_spikesorting.py
@@ -289,9 +289,9 @@ class SpikeSortingRecordingSelection(dj.Manual):
     -> SortGroup
     -> SortInterval
     -> SpikeSortingPreprocessingParameters
+    -> LabTeam
     ---
     -> IntervalList
-    -> LabTeam
     """
 
 @schema


### PR DESCRIPTION
addresses issue #133 