### PR TITLE
use kachery_temp_dir from kachery_client package

### DIFF
--- a/src/nwb_datajoint/common/__init__.py
+++ b/src/nwb_datajoint/common/__init__.py
@@ -42,4 +42,6 @@ from .populate_all_common import populate_all_common
 import spikeinterface as si
 import os
 
-si.set_global_tmp_folder(os.environ['KACHERY_TEMP_DIR'])
+from ._kachery_temp_dir import kachery_temp_dir
+
+si.set_global_tmp_folder(kachery_temp_dir)

--- a/src/nwb_datajoint/common/_kachery_temp_dir.py
+++ b/src/nwb_datajoint/common/_kachery_temp_dir.py
@@ -1,0 +1,11 @@
+from kachery_client._daemon_connection import _kachery_temp_dir
+
+# This will be $KACHERY_TEMP_DIR if this env variable set
+# Otherwise, if not set, this will be tempfile.gettempdir() + '/kachery-tmp'
+kachery_temp_dir = _kachery_temp_dir()
+
+# Note that in the future, this _kachery_temp_dir() will be exposed in a better way
+# from kachery_client. Probably something like:
+#
+# import kachery_client as kc
+# kc.TemporaryDirectory.get_temp_dir()

--- a/src/nwb_datajoint/common/common_spikesorting.py
+++ b/src/nwb_datajoint/common/common_spikesorting.py
@@ -26,6 +26,7 @@ from .common_session import Session
 from .dj_helper_fn import dj_replace, fetch_nwb
 from .nwb_helper_fn import get_valid_intervals
 
+from ._kachery_temp_dir import kachery_temp_dir
 
 class Timer:
     """
@@ -537,7 +538,7 @@ class SpikeSorting(dj.Computed):
         print(f'Running spike sorting on {key}...')
         sorter, sorter_params = (SpikeSorterParameters & key).fetch1('sorter','sorter_params')
         sorting = ss.run_sorter(sorter, recording,
-                                output_folder=os.getenv('KACHERY_TEMP_DIR'),
+                                output_folder=kachery_temp_dir,
                                 delete_output_folder=True,
                                 **sorter_params)
         key['time_of_sort'] = int(time.time())


### PR DESCRIPTION
With this change, the kachery temp dir is obtained from the `kachery_client` package rather than directly from the `KACHERY_TEMP_DIR` env variable.

If KACHERY_TEMP_DIR env variable is set, then there is no change in behavior.

If not set, then it will use: `this will be tempfile.gettempdir() + '/kachery-tmp'`

This allows nwb_datajoint to run on systems where KACHERY_TEMP_DIR is not set.
