### PR TITLE
PROPOSAL: implement SessionGroup

### DIFF
--- a/docs/session_groups.md
+++ b/docs/session_groups.md
@@ -1,0 +1,25 @@
+# Session groups
+
+A session group is a collection of sessions. Each group has a name (primary key) and a description.
+
+```python
+from nwb_datajoint.common import SessionGroup
+
+# Create a new session group
+SessionGroup.add_group('test_group_1', 'Description of test group 1')
+
+# Get the table of session groups
+SessionGroup()
+
+# Add a session to the group
+SessionGroup.add_session_to_group('RN2_20191110_.nwb', 'test_group_1')
+
+# Remove a session from a group
+# SessionGroup.remove_session_from_group('RN2_20191110_.nwb', 'test_group_1')
+
+# Get all sessions in group
+SessionGroup.get_group_sessions('test_group_1')
+
+# Update the description of a session group
+SessionGroup.update_session_group_description('test_group_1', 'Test description')
+```

--- a/src/nwb_datajoint/common/__init__.py
+++ b/src/nwb_datajoint/common/__init__.py
@@ -21,7 +21,7 @@ from .common_nwbfile import (AnalysisNwbfile, AnalysisNwbfileKachery, Nwbfile,
                              NwbfileKachery)
 from .common_region import BrainRegion
 from .common_sensors import SensorData
-from .common_session import ExperimenterList, Session
+from .common_session import ExperimenterList, Session, SessionGroup
 from .common_spikesorting import (SortGroup, SpikeSortingPreprocessingParameters,
                                   SpikeSortingRecordingSelection, SpikeSortingRecording,SpikeSorterParameters,
                                   SpikeSortingSelection, SpikeSorting, Sortings)


### PR DESCRIPTION
With this PR I propose to create a SessionGroup table comprising groups of sessions.

This is a needed in the development of spyglassview (figurl view of spyglass sessions) to allow the user to choose exactly the collection of sessions they want to view (or share a view with others). This could also be helpful in eventually making a subset of the data available for readonly public access. I could also imagine this being useful for users who want to organize their studies.

Each session group has a name (primary key) and a description. See [session_groups.md](https://github.com/scratchrealm/nwb_datajoint/blob/session-groups/docs/session_groups.md) for the proposed usage.

@lfrank @rly @edeno @khl02007 @jsoules 