### PR TITLE
Change n_jobs from 4 to 1 for saving new recordings

### DIFF
--- a/src/nwb_datajoint/common/common_spikesorting.py
+++ b/src/nwb_datajoint/common/common_spikesorting.py
@@ -323,7 +323,7 @@ class SpikeSortingRecording(dj.Computed):
         key['recording_path'] = str(recording_folder / Path(recording_name))
         if os.path.exists(key['recording_path']):
             shutil.rmtree(key['recording_path'])
-        recording = recording.save(folder=key['recording_path'], n_jobs=4,
+        recording = recording.save(folder=key['recording_path'], n_jobs=1,
                                    total_memory='5G')
         
         key['recording_id'] = 'R_'+str(uuid.uuid4())[:8]

--- a/src/nwb_datajoint/common/common_spikesorting.py
+++ b/src/nwb_datajoint/common/common_spikesorting.py
@@ -324,7 +324,7 @@ class SpikeSortingRecording(dj.Computed):
         if os.path.exists(key['recording_path']):
             shutil.rmtree(key['recording_path'])
         recording = recording.save(folder=key['recording_path'], n_jobs=1,
-                                   total_memory='5G')
+                                   total_memory='10G')
         
         key['recording_id'] = 'R_'+str(uuid.uuid4())[:8]
         


### PR DESCRIPTION
This is just a band-aid for unblocking folks. See issue #150 (maybe #153 ?). This PR simply changes n_jobs = 1 instead of 4 to address some parallelization issues. For longer term solution, I propose exposing n_jobs and total_memory as parameters the user can define depending on their known compute resources (5GB probably doesn't make sense on a virga, for ex... maybe we should also bump this up to something like 100GB for now?). These params could either go in SpikeSortingPreprocessingParameters or another more appropriate place.

Based on my experience, just to keep track -
* n_jobs = 4, three epochs of run data from one day: is extremely slow (> 4 hours on this attempt so far), I expect it to error out but it hasn't yet... still running. Based on htop, doesn't look like much is going on.
* n_jobs = 4, one epoch/20 mins of continuous run data: works
* n_jobs = 4, 200 seconds with a discontinuity in it (end of one run and beginning of another run): works - so it isn't just the discontinuities in the interval
* n_jobs = 1, one epoch of continuous run data: works
* n_jobs = 1, three epochs of run data from one day: works (<< 30 mins !)